### PR TITLE
update go-qrcode install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To see a working instance of shadowchat, see [xmr.lukesmith.xyz](https://xmr.luk
 1. ```apt install golang```
 2. ```git clone https://git.sr.ht/~anon_/shadowchat```
 4. ```cd shadowchat```
-2. ```go get github.com/skip2/go-qrcode```
+2. ```go install github.com/skip2/go-qrcode@latest```
 5. ```go mod init shadowchat && go mod tidy```
 6. edit ```config.json```
 7. ```go run main.go```


### PR DESCRIPTION
Hi

If you try to run the command as currently in the README you get the following warning message:

```
$ go get github.com/skip2/go-qrcode
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

This PR uses the updated command.