### PR TITLE
update repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To see a working instance of shadowchat, see [xmr.lukesmith.xyz](https://xmr.luk
 # Installation
 
 1. ```apt install golang```
-2. ```git clone https://git.sr.ht/~anon_/shadowchat```
+2. ```git clone https://github.com/LukeSmithxyz/shadowchat```
 3. ```cd shadowchat```
 4. ```go install github.com/skip2/go-qrcode@latest```
 5. edit ```config.json```


### PR DESCRIPTION
With the old link the installation instructions don't work anymore because it doesn't have a go.mod file